### PR TITLE
Add patching of JVM GC log settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ RUN set -ex \
     && bin/elasticsearch-plugin install --batch repository-gcs \
     && bin/elasticsearch-plugin install --batch repository-s3
 
-RUN sed -r "s/filecount=[0-9]+,filesize=[0-9]+[kmg]/filecount=4,filesize=64m/" -i /usr/share/elasticsearch/config/jvm.options
+RUN sed -i -E "s/(8:-XX:NumberOfGCLogFiles=)\w+/\14/" /usr/share/elasticsearch/config/jvm.options \
+  && sed -i -E "s/(9-:-Xlog:gc.+filecount=)[^:,]+(.*)/\14\2/" /usr/share/elasticsearch/config/jvm.options 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN set -ex \
     && bin/elasticsearch-plugin install --batch repository-gcs \
     && bin/elasticsearch-plugin install --batch repository-s3
 
-RUN sed -i -E "s/(8:-XX:NumberOfGCLogFiles=)\w+/\14/" /usr/share/elasticsearch/config/jvm.options \
-  && sed -i -E "s/(9-:-Xlog:gc.+filecount=)[^:,]+(.*)/\14\2/" /usr/share/elasticsearch/config/jvm.options 
+# Reduce the number of rotated JVM GC logs we keep to avoid filling k8s ephemeral storage
+RUN sed -r "s/NumberOfGCLogFiles=[0-9]+/NumberOfGCLogFiles=4/" -i /usr/share/elasticsearch/config/jvm.options \
+  && sed -r "s/filecount=[0-9]+,filesize=[0-9]+[kmg]/filecount=4,filesize=64m/" -i /usr/share/elasticsearch/config/jvm.options

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,5 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN set -ex \
     && bin/elasticsearch-plugin install --batch repository-gcs \
     && bin/elasticsearch-plugin install --batch repository-s3
+
+RUN sed -r "s/filecount=[0-9]+,filesize=[0-9]+[kmg]/filecount=4,filesize=64m/" -i /usr/share/elasticsearch/config/jvm.options


### PR DESCRIPTION
Didn't want to mount our own config file in case the upstream one changes.

I tried to make this generic and safe from future changes upstream.